### PR TITLE
Keep connection alive & use dos2unix on shell scripts

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,5 +6,6 @@ COPY app /app
 RUN set -xe \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ openconnect expect privoxy runit\
     && touch /mnt/vars.config \
-    && find /app -name run | xargs chmod u+x
+    && find /app -name run | xargs chmod u+x\
+    && find /app -type f | xargs dos2unix
 CMD ["runsvdir", "/app"]

--- a/image/app/pinger/run
+++ b/image/app/pinger/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+while sleep 1500; do wget --spider https://confluence.ccta.dk/; done


### PR DESCRIPTION
add shell script to ping confluence every 1500 seconds to keep connection alive

add dos2unix command to setup command to ensure correct encoding